### PR TITLE
put a sleep in code to getPendings from GLPI can list the queue

### DIFF
--- a/front/mfa.form.php
+++ b/front/mfa.form.php
@@ -101,6 +101,7 @@ if (isset($_POST['code'])) {
                 $mfa = new PluginMfaMfa();
                 $mfa->add(['users_id' => Session::getLoginUserID(), 'code' => PluginMfaMfa::getRandomInt(6)]);
                 NotificationEvent::raiseEvent('securitycodegenerate', $mfa, ['entities_id' => 0]);
+                sleep(1);
                 QueuedNotification::forceSendFor($mfa->getType(), $mfa->fields['id']);
             }
             Session::destroy();


### PR DESCRIPTION
Because the inside function on GLPI `getPendings` use just `<` on filter, the notification just created, less than 1 second is not available yet.
Put a `sleep(1);` before call `QueuedNotification::forceSendFor` is enough to send the OTP immediately.

If the GLPI team adjust the filter in `getPendings` to `<=` this PR is not necessary 